### PR TITLE
[fix]not redirected when login with username

### DIFF
--- a/src/page/index.tsx
+++ b/src/page/index.tsx
@@ -93,8 +93,11 @@ export class PageRouter extends mixin<{}, PageRouterState>() {
             title: document.title,
             logo
         });
-        const { data } = await new Promise(resolve =>
-            dialog.on('login', resolve)
+        const data = await new Promise(resolve =>
+            dialog.on('login', loginData => {
+                const { data } = loginData;
+                resolve(data || loginData);
+            })
         );
         await session.signIn(data);
 


### PR DESCRIPTION
when login with username/password, the result of Authing Guard is not in { data } field as login with GitHub account