### PR TITLE
fix: use email or phone as nickname if not present

### DIFF
--- a/src/page/index.tsx
+++ b/src/page/index.tsx
@@ -94,6 +94,8 @@ export class PageRouter extends mixin<{}, PageRouterState>() {
         });
         const data = await new Promise(resolve => dialog.on('login', resolve));
 
+        if(!data.nickname)
+            data.nickname = data.email || data.phone
         await session.signIn(data);
 
         document.querySelector('#sign-in').innerHTML = '';


### PR DESCRIPTION
使用email注册的账号，在登录时因为没有nickname后台login接口会报错。目前简单处理，自动使用用户的email或电话号码填充nickname字段。更好的方式是前端弹出一个表单，让用户设置自己的nickname（并且反向同步到authing，下次登录时authing就会返回），或者直接跳转到authing的用户信息设置界面。