### PR TITLE
fix: show team members count, creator and default logo in team list

### DIFF
--- a/src/model/Team.ts
+++ b/src/model/Team.ts
@@ -10,14 +10,14 @@ interface Membership {
 
 export interface Team extends DataItem {
     works: any[];
-    member_count: number;
+    membersCount: number;
     displayName: string;
     description: string;
     cover: string;
     members: Membership[];
     awards: any[];
     logo: string;
-    leader: User;
+    creator: User;
     hackathonName: string;
     azure_keys: any[];
     templates: any[];

--- a/src/page/Activity/Detail.tsx
+++ b/src/page/Activity/Detail.tsx
@@ -189,9 +189,9 @@ export class ActivityDetail extends mixin() {
             </div>
             <div className="p-2">
                 {words.team_leader}：
-                <a href={'user?uid=' + creator?.id}>
-                    <img className={style.icon} src={creator?.photo || defaultLogo} />{' '}
-                    {creator?.nickname}
+                <a href={'user?uid=' + creator.id}>
+                    <img className={style.icon} src={creator.photo || defaultLogo} />{' '}
+                    {creator.nickname}
                 </a>
             </div>
         </li>

--- a/src/page/Activity/Detail.tsx
+++ b/src/page/Activity/Detail.tsx
@@ -169,8 +169,8 @@ export class ActivityDetail extends mixin() {
         logo,
         id,
         displayName,
-        member_count,
-        leader
+        membersCount,
+        creator
     }: Team) => (
         <li className="border overflow-hidden mb-3" style={{ width: '200' }}>
             <div className="d-flex border-bottom">
@@ -182,15 +182,15 @@ export class ActivityDetail extends mixin() {
                         </a>
                     </h4>
                     {words.a_total_of}
-                    <span className="mx-2 text-success">{member_count}</span>
+                    <span className="mx-2 text-success">{membersCount}</span>
                     {words.people}
                 </div>
             </div>
             <div className="p-2">
                 {words.team_leader}：
-                <a href={'user?uid=' + leader?.id}>
-                    <img className={style.icon} src={leader?.phone} />{' '}
-                    {leader?.nickname}
+                <a href={'user?uid=' + creator?.id}>
+                    <img className={style.icon} src={creator?.photo} />{' '}
+                    {creator?.nickname}
                 </a>
             </div>
         </li>

--- a/src/page/Activity/Detail.tsx
+++ b/src/page/Activity/Detail.tsx
@@ -25,6 +25,7 @@ import style from './Detail.module.less';
 import { TimeUnitName, isMobile } from '../../utility';
 import { words } from '../../i18n';
 import { activity, RegistrationStatus, Team } from '../../model';
+import defaultLogo from '../../image/logo.png';
 
 @observer
 @component({
@@ -174,7 +175,7 @@ export class ActivityDetail extends mixin() {
     }: Team) => (
         <li className="border overflow-hidden mb-3" style={{ width: '200' }}>
             <div className="d-flex border-bottom">
-                <img className={style.logo} src={logo} />
+                <img className={style.logo} src={logo || defaultLogo} />
                 <div className="flex-shrink-1">
                     <h4 className="text-nowrap my-1">
                         <a href={`team?activity=${hackathonName}&tid=${id}`}>
@@ -189,7 +190,7 @@ export class ActivityDetail extends mixin() {
             <div className="p-2">
                 {words.team_leader}：
                 <a href={'user?uid=' + creator?.id}>
-                    <img className={style.icon} src={creator?.photo} />{' '}
+                    <img className={style.icon} src={creator?.photo || defaultLogo} />{' '}
                     {creator?.nickname}
                 </a>
             </div>


### PR DESCRIPTION
- 根据新的API修改字段名，在活动详情页的团队列表中展示团队成员数量、创建者（队长）信息
- 用平台的logo作为默认的团队logo和创建者头像