### PR TITLE
fix: enrollment count, registration closing tips, etc.

### DIFF
--- a/src/component/ActivityCard.tsx
+++ b/src/component/ActivityCard.tsx
@@ -109,9 +109,9 @@ export function ActivityCard({
                             words.days
                         )}
                     </time>
-                    <span>
+                    {/* <span>
                         <FAIcon name="heart" color="danger" /> {stat?.like}
-                    </span>
+                    </span> */}
                     <span>
                         {textJoin(
                             (stat?.register || 0) + '',

--- a/src/component/ActivityCard.tsx
+++ b/src/component/ActivityCard.tsx
@@ -103,11 +103,11 @@ export function ActivityCard({
             <CardFooter>
                 <small className="d-flex justify-content-between mb-2">
                     <time dateTime={event_end.toJSON()}>
-                        {textJoin(
+                        {days >= 0 ? textJoin(
                             words.registration_deadline,
-                            days < 0 ? '--' : days + '',
+                            days + '',
                             words.days
-                        )}
+                        ) : ''}
                     </time>
                     {/* <span>
                         <FAIcon name="heart" color="danger" /> {stat?.like}

--- a/src/component/ActivityCard.tsx
+++ b/src/component/ActivityCard.tsx
@@ -23,7 +23,7 @@ export function ActivityCard({
     tags,
     enrollmentEndedAt,
     status,
-    stat,
+    enrollment,
     creatorId,
     manage,
     onPublish,
@@ -114,7 +114,7 @@ export function ActivityCard({
                     </span> */}
                     <span>
                         {textJoin(
-                            (stat?.register || 0) + '',
+                            enrollment + '',
                             words.people,
                             words.registered
                         )}

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -28,7 +28,7 @@ export enum en_US {
     most_popular = 'Most popular',
     upcoming_events = 'Upcoming events',
     more_events = 'More events',
-    registration_deadline = 'Registration deadline',
+    registration_deadline = 'Registration closing in',
     registered = 'registered',
     register = 'Register',
     registration_closed = 'Registration Closed',

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -28,7 +28,7 @@ export enum zh_CN {
     most_popular = '人气热点',
     upcoming_events = '即将开始',
     more_events = '更多活动',
-    registration_deadline = '报名截止',
+    registration_deadline = '距报名截止还有',
     registered = '已报名',
     register = '报名',
     registration_closed = '报名已截止',

--- a/src/i18n/zh-TW.ts
+++ b/src/i18n/zh-TW.ts
@@ -28,7 +28,7 @@ export enum zh_TW {
     most_popular = '人氣熱點',
     upcoming_events = '即將開始',
     more_events = '更多活動',
-    registration_deadline = '報名截止',
+    registration_deadline = '距報名截止還有',
     registered = '已報名',
     register = '報名',
     registration_closed = '報名已截止',

--- a/src/model/Activity.ts
+++ b/src/model/Activity.ts
@@ -38,6 +38,7 @@ export interface Activity extends DataItem {
     tags?: string[];
     banners: Asset[];
     location?: string;
+    enrollment: number;
     maxEnrollment: number;
     coord?: Coord;
     enrollmentStartedAt: string;

--- a/src/page/Activity/Detail.tsx
+++ b/src/page/Activity/Detail.tsx
@@ -117,7 +117,7 @@ export class ActivityDetail extends mixin() {
                     <li>
                         {words.registration_count}
                         <FAIcon name="users" color="success" className="mx-2" />
-                        {textJoin((enrollment || 0) + '', words.people)}
+                        {textJoin(enrollment + '', words.people)}
                     </li>
                 </ul>
                 {!roles?.isEnrolled ? (

--- a/src/page/Activity/Detail.tsx
+++ b/src/page/Activity/Detail.tsx
@@ -71,7 +71,7 @@ export class ActivityDetail extends mixin() {
             eventEndedAt,
             location,
             roles,
-            stat
+            enrollment
         } = activity.current;
 
         return (
@@ -117,7 +117,7 @@ export class ActivityDetail extends mixin() {
                     <li>
                         {words.registration_count}
                         <FAIcon name="users" color="success" className="mx-2" />
-                        {textJoin((stat?.register || 0) + '', words.people)}
+                        {textJoin((enrollment || 0) + '', words.people)}
                     </li>
                 </ul>
                 {!roles?.isEnrolled ? (


### PR DESCRIPTION
- 在首页活动卡片和黑客松详情页修改了报名人数字段，使用新的字段名
- 在首页活动卡片上隐藏了喜欢人数，后台还没有API
- 在首页活动卡片上更新了报名截止日期的文案